### PR TITLE
Gateway action

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "yarn clean && yarn build:node8 && yarn build:node6",
     "build:node8": "babel src -d lib",
     "build:node6": "BABEL_ENV=node6 babel src -d node6",
-    "test": "docker-compose up -d mqtt && sleep 5 && jest"
+    "test": "yarn build && docker-compose up -d mqtt && sleep 5 && jest"
   },
   "main": "lib/index.js",
   "author": "Brad Decker",

--- a/src/Gateway/GraphQLGateway.js
+++ b/src/Gateway/GraphQLGateway.js
@@ -8,7 +8,7 @@
  * @flow
  */
 import { mergeSchemas } from 'graphql-tools';
-import { printSchema, parse } from 'graphql';
+import { printSchema, parse, graphql as execute } from 'graphql';
 import difference from 'lodash.difference';
 import selectn from 'selectn';
 import fs from 'fs';
@@ -141,6 +141,15 @@ export class GraphQLGateway {
         '$services.changed': this.handleServiceUpdate,
         '$node.connected': this.handleNodeConnection,
         '$node.disconnected': this.handleNodeDisconnected,
+      },
+      actions: {
+        graphql: {
+          params: {
+            query: { type: 'string' },
+            variables: { type: 'object', optional: true }
+          },
+          handler: ctx => execute(this.schema, ctx.params.query, null, null, ctx.params.variables),
+        },
       },
     });
   }

--- a/tests/queryResolution.spec.js
+++ b/tests/queryResolution.spec.js
@@ -1,0 +1,267 @@
+/**
+ * @file Test the resolution of queries (remotely and within gateway)
+ * @author Nathan Schwartz <nathan.schwartz95@gmail.com>
+ *
+ * This file ends up feeling a bit abstract because it reuses suites and assertions.
+ *
+ * The only thing that really changes between runs is how the queries are resolved.
+ *
+ * This is done by passing in a resolveQuery function. The resolveQuery function is partially
+ * applied within the test suite to provide access to a moleculer broker and the gateway.
+ */
+import { ServiceBroker, Transporters } from 'moleculer';
+import { graphql as execute } from 'graphql';
+import { GraphQLGateway } from '..';
+import authorSvc from './types/Author';
+import bookSvc from './types/Book';
+import chapterSvc from './types/chapter';
+import * as dataSource from './types/data';
+
+jest.setTimeout(10000);
+
+/**
+ * @param {function} resolveQuery
+ *
+ * This function will run queries using a passed in resolution method. The only thing passed to
+ * the resolveQuery function is a string containing the GraphQL query.
+ */
+const runTests = (resolveQuery) => {
+  test('Should be able to query for all authors', async () => {
+    const { data } = await resolveQuery(`{
+      authors {
+        name,
+        id,
+      }
+    }`);
+
+    expect(data).toEqual({ authors: dataSource.authors });
+  });
+
+  test('Should be able to include books on author query', async () => {
+    const { data } = await resolveQuery(`{
+      authors {
+        name,
+        id,
+        books {
+          title,
+          year,
+          authorId,
+          id
+        }
+      }
+    }`);
+    expect(data).toEqual({
+      authors: dataSource.authors.map(author => ({
+        ...author,
+        books: dataSource.books.filter(book => book.authorId === author.id),
+      })),
+    });
+  });
+
+  test('Should be able to include chapters inside books on author query', async () => {
+    const { data } = await resolveQuery(`{
+      authors {
+        name,
+        id,
+        books {
+          title,
+          year,
+          authorId,
+          id
+          chapters {
+            title,
+            id,
+            bookId,
+          }
+        }
+      }
+    }`);
+
+    expect(data).toEqual({
+      authors: dataSource.authors.map(author => ({
+        ...author,
+        books: dataSource.books.filter(book => book.authorId === author.id).map(book => ({
+          ...book,
+          chapters: dataSource.chapters.filter(chapter => chapter.bookId === book.id)
+        }))
+      })),
+    });
+  });
+
+  test('Should be able to query for all books', async () => {
+    const { data } = await resolveQuery(`{
+      books {
+        title,
+        year,
+        id,
+        authorId
+      }
+    }`);
+    expect(data).toEqual({ books: dataSource.books });
+  });
+
+  test('Should be able to include the author in the books query', async () => {
+    const { data } = await resolveQuery(`{
+      books {
+        title,
+        year,
+        id,
+        authorId
+        author {
+          name
+          id
+        }
+      }
+    }`);
+    expect(data).toEqual({ books: dataSource.books.map(book => ({
+      ...book,
+      author: dataSource.authors.find(author => author.id === book.authorId)
+    })) });
+  });
+
+  test('Should be able to include the chapters in the books query', async () => {
+    const { data } = await resolveQuery(`{
+      books {
+        title,
+        year,
+        id,
+        authorId
+        chapters {
+          bookId
+          title
+          id
+        }
+      }
+    }`);
+    expect(data).toEqual({ books: dataSource.books.map(book => ({
+      ...book,
+      chapters: dataSource.chapters.filter(chapter => chapter.bookId === book.id)
+    })) });
+  });
+}
+
+/**
+ * @param {string} suiteName
+ * @param {function} buildQueryResolver
+ *
+ * The query resolvers need access to either a moleculer client, or the schema property on
+ * the gateway service. Because the gateway and client are intialized to a null value and will be
+ * reassigned between tests, the best we can do is to pass a reference to them.
+ *
+ * This is why all brokers are contained in an object called ref.
+ */
+const runSuites = (suiteName, buildQueryResolver) => {
+  describe(suiteName, () => {
+    describe('With A Single Broker', () => {
+      // Globals for With a Single Broker
+      const ref = {
+        broker: null,
+        gateway: null,
+      }
+
+      beforeAll(() => {
+        ref.broker = new ServiceBroker({
+          nodeID: 'gatewaySingle',
+        });
+
+        ref.broker.createService(authorSvc);
+        ref.broker.createService(bookSvc);
+        ref.broker.createService(chapterSvc);
+
+        ref.broker.start();
+
+        ref.gateway = new GraphQLGateway({
+          broker: ref.broker,
+        });
+
+        return ref.gateway.start();
+      });
+
+      afterAll(() => ref.broker.stop());
+
+      runTests(buildQueryResolver({ ref, clientKey: 'broker' }));
+    });
+
+    describe('With Multiple Brokers', () => {
+      // Globals for With a Single Broker
+      const ref = {
+        broker: null,
+        authorBroker: null,
+        bookBroker: null,
+        chapterBroker: null,
+        gateway: null,
+        client: null,
+      }
+
+      beforeAll(() => {
+        ref.client = new ServiceBroker({
+          nodeID: 'client',
+          transporter: new Transporters.MQTT('mqtt://localhost:1883')
+        });
+
+        ref.broker = new ServiceBroker({
+          nodeID: 'gatewayMultiple',
+          transporter: new Transporters.MQTT('mqtt://localhost:1883')
+        });
+
+        ref.authorBroker = new ServiceBroker({
+          nodeID: 'author',
+          transporter: new Transporters.MQTT('mqtt://localhost:1883')
+        });
+
+        ref.bookBroker = new ServiceBroker({
+          nodeID: 'book',
+          transporter: new Transporters.MQTT('mqtt://localhost:1883')
+        });
+
+        ref.chapterBroker = new ServiceBroker({
+          nodeID: 'chapter',
+          transporter: new Transporters.MQTT('mqtt://localhost:1883')
+        });
+
+        ref.authorBroker.createService(authorSvc);
+        ref.bookBroker.createService(bookSvc);
+        ref.chapterBroker.createService(chapterSvc);
+
+        ref.gateway = new GraphQLGateway({
+          broker: ref.broker,
+        });
+
+        return Promise.all([
+          ref.client.start(),
+          ref.authorBroker.start(),
+          ref.bookBroker.start(),
+          ref.chapterBroker.start(),
+          ref.broker.start(),
+          ref.gateway.start(),
+        ])
+      });
+
+      afterAll(() => Promise.all([
+        ref.client.stop(),
+        ref.authorBroker.stop(),
+        ref.bookBroker.stop(),
+        ref.chapterBroker.stop(),
+        ref.broker.stop(),
+      ]))
+
+      runTests(buildQueryResolver({ ref, clientKey: 'client' }));
+    });
+  });
+}
+
+
+runSuites(
+  'Moleculer Action Query Resolution',
+  ({ ref, clientKey }) => query => {
+    // We use clientKey because in the "single broker" suite, the "client" is the broker.
+    // Making a wrapper object, duplicating the key, or misnaming broker seemed like worse options.
+    const client = ref[clientKey];
+    return client.call('gateway.graphql', { query });
+  }
+);
+
+runSuites(
+  'Schema Execution Query Resolution',
+  ({ ref }) => query => execute(ref.gateway.schema, query)
+);

--- a/tests/schemaGeneration.spec.js
+++ b/tests/schemaGeneration.spec.js
@@ -1,123 +1,11 @@
 import { ServiceBroker, Transporters } from 'moleculer';
-import { graphql as execute, printSchema } from 'graphql';
-import { GraphQLGateway } from '../src/Gateway/GraphQLGateway';
+import { printSchema } from 'graphql';
+import { GraphQLGateway } from '..';
 import authorSvc from './types/Author';
 import bookSvc from './types/Book';
 import chapterSvc from './types/chapter';
-import * as dataSource from './types/data';
 
 jest.setTimeout(10000);
-
-async function authorsQuery(schema) {
-  const { data } = await execute(schema, `{
-    authors {
-      name,
-      id,
-    }
-  }`);
-  expect(data).toEqual({ authors: dataSource.authors });
-}
-
-async function authorsWithBooksQuery(schema) {
-  const { data } = await execute(schema, `{
-    authors {
-      name,
-      id,
-      books {
-        title,
-        year,
-        authorId,
-        id
-      }
-    }
-  }`);
-  expect(data).toEqual({
-    authors: dataSource.authors.map(author => ({
-      ...author,
-      books: dataSource.books.filter(book => book.authorId === author.id),
-    })),
-  });
-}
-
-async function authorsWithBooksAndChaptersQuery(schema) {
-  const { data } = await execute(schema, `{
-    authors {
-      name,
-      id,
-      books {
-        title,
-        year,
-        authorId,
-        id
-        chapters {
-          title,
-          id,
-          bookId,
-        }
-      }
-    }
-  }`);
-  expect(data).toEqual({
-    authors: dataSource.authors.map(author => ({
-      ...author,
-      books: dataSource.books.filter(book => book.authorId === author.id).map(book => ({
-        ...book,
-        chapters: dataSource.chapters.filter(chapter => chapter.bookId === book.id)
-      }))
-    })),
-  });
-}
-
-async function booksQuery(schema) {
-  const { data } = await execute(schema, `{
-    books {
-      title,
-      year,
-      id,
-      authorId
-    }
-  }`);
-  expect(data).toEqual({ books: dataSource.books });
-}
-
-async function booksWithAuthorQuery(schema) {
-  const { data } = await execute(schema, `{
-    books {
-      title,
-      year,
-      id,
-      authorId
-      author {
-        name
-        id
-      }
-    }
-  }`);
-  expect(data).toEqual({ books: dataSource.books.map(book => ({
-    ...book,
-    author: dataSource.authors.find(author => author.id === book.authorId)
-  })) });
-}
-
-async function booksWithChaptersQuery(schema) {
-  const { data } = await execute(schema, `{
-    books {
-      title,
-      year,
-      id,
-      authorId
-      chapters {
-        bookId
-        title
-        id
-      }
-    }
-  }`);
-  expect(data).toEqual({ books: dataSource.books.map(book => ({
-    ...book,
-    chapters: dataSource.chapters.filter(chapter => chapter.bookId === book.id)
-  })) });
-}
 
 describe('Schema Generation', () => {
   describe('With A Single Broker', () => {
@@ -144,30 +32,6 @@ describe('Schema Generation', () => {
     });
 
     afterAll(() => broker.stop());
-
-    test('Should be able to query for all authors', async () => {
-      return await authorsQuery(gateway.schema);
-    });
-
-    test('Should be able to include books on author query', async () => {
-      return await authorsWithBooksQuery(gateway.schema);
-    });
-
-    test('Should be able to include chapters inside books on author query', async () => {
-      await authorsWithBooksAndChaptersQuery(gateway.schema);
-    });
-
-    test('Should be able to query for all books', async () => {
-      await booksQuery(gateway.schema);
-    });
-
-    test('Should be able to include the author in the books query', async () => {
-      await booksWithAuthorQuery(gateway.schema);
-    });
-
-    test('Should be able to include the chapters in the books query', async () => {
-      await booksWithChaptersQuery(gateway.schema);
-    });
 
     test('Should generate a consistant schema', () => {
       expect(printSchema(gateway.schema)).toMatchSnapshot();
@@ -226,30 +90,6 @@ describe('Schema Generation', () => {
       bookBroker.stop();
       chapterBroker.stop();
     })
-
-    test('Should be able to query for all authors', async () => {
-      return await authorsQuery(gateway.schema);
-    });
-
-    test('Should be able to include books on author query', async () => {
-      return await authorsWithBooksQuery(gateway.schema);
-    });
-
-    test('Should be able to include chapters inside books on author query', async () => {
-      await authorsWithBooksAndChaptersQuery(gateway.schema);
-    });
-
-    test('Should be able to query for all books', async () => {
-      await booksQuery(gateway.schema);
-    });
-
-    test('Should be able to include the author in the books query', async () => {
-      await booksWithAuthorQuery(gateway.schema);
-    });
-
-    test('Should be able to include the chapters in the books query', async () => {
-      await booksWithChaptersQuery(gateway.schema);
-    });
 
     test('Should generate a consistant schema', () => {
       expect(printSchema(gateway.schema)).toMatchSnapshot();

--- a/tests/serviceDiscovery.spec.js
+++ b/tests/serviceDiscovery.spec.js
@@ -1,7 +1,7 @@
 import { ServiceBroker, Transporters } from 'moleculer';
 import { graphql as execute, printSchema } from 'graphql';
 import { promisify } from 'util';
-import { GraphQLGateway } from '../src/Gateway/GraphQLGateway';
+import { GraphQLGateway } from '..';
 import authorSvc from './types/Author';
 import bookSvc from './types/Book';
 import chapterSvc from './types/chapter';


### PR DESCRIPTION
This PR adds a `gateway.graphql` action to handle queries and mutations within a Moleculer network without needing to make HTTP requests to the gateway's express-graphql server (for instance).